### PR TITLE
Fixed ManyToMany Entity Seed

### DIFF
--- a/POC/Data/POCApiContext.cs
+++ b/POC/Data/POCApiContext.cs
@@ -13,6 +13,8 @@ public class POCApiContext : DbContext
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.UseInMemoryDatabase("DatabaseForTesting");
+
+
     }
 
     public DbSet<Person> People { get; set; }
@@ -21,7 +23,26 @@ public class POCApiContext : DbContext
 
     public DbSet<Product> Products { get; set; }
 
-    public DbSet<OrderItems> OrdersItems { get; set; }
-
     public DbSet<Supplier> Suppliers { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder mb)
+    {
+        mb.Entity<Product>(d =>
+        {
+            d.HasKey(d => d.Id);
+            d.HasMany(d => d.Orders).WithMany(d => d.Products);
+        });
+        mb.Entity<Order>(d =>
+        {
+            d.HasKey(d => d.Id);
+            d.HasMany(d => d.Products).WithMany(d => d.Orders);
+            d.HasOne(d => d.Person).WithMany(d => d.Orders).HasForeignKey(d => d.PersonId);
+        });
+
+        mb.Entity<Person>(d =>
+        {
+            d.HasKey(d => d.Id);
+            d.HasMany(d => d.Orders).WithOne(d => d.Person).HasForeignKey(d => d.PersonId);
+        });
+    }
 }

--- a/POC/Model/Order.cs
+++ b/POC/Model/Order.cs
@@ -4,6 +4,10 @@ public class Order
 {
     public Guid Id { get; set; }
     public DateTime OrderTime { get; set; }
+
+
+    public Guid PersonId { get; set; }
     public Person Person { get; set; }
-    public List<OrderItems> OrderItems { get; set; }
+
+    public List<Product> Products { get; set; }
 }

--- a/POC/Model/OrderItems.cs
+++ b/POC/Model/OrderItems.cs
@@ -1,9 +1,0 @@
-﻿namespace POC.Model;
-
-public class OrderItems
-{
-    public Guid Id { get; set; }
-    public Order Order { get; set; }
-    public Product Product { get; set; }
-    public uint Qty { get; set; }
-}

--- a/POC/Model/Product.cs
+++ b/POC/Model/Product.cs
@@ -5,6 +5,6 @@ public class Product
     public Guid Id { get; set; }
     public string ProductName { get; set; }
     public decimal Price { get; set; }
-    public List<OrderItems> OrderItems { get; set; }
+    public List<Order> Orders { get; set; }
     public Supplier Supplier { get; set; }
 }

--- a/POC/Seeders/OrdersItemsSeeder.cs
+++ b/POC/Seeders/OrdersItemsSeeder.cs
@@ -6,25 +6,27 @@ using POC.Model;
 
 namespace POC.Seeders;
 
-public class OrdersItemsSeeder : IActualSeeder<OrderItems, POCApiContext>
+public class OrdersItemsSeeder : IActualSeeder<Order, Product, POCApiContext>
 {
     public void Seed(POCApiContext context, ILogger logger)
     {
-        List<OrderItems> orderItems = new List<OrderItems>();
+        context.SaveChanges();
+        var orders = context.Orders;
+        var products = context.Products;
 
-        var orders = context.Orders.Local.ToList();
-        var products = context.Products.Local.ToList();
-        var faker = new Faker();
         foreach (var order in orders)
         {
             var numitems = new Faker().Random.Int(1, 4);
-            var orderi = new Faker<OrderItems>("pt_BR")
-                .RuleFor(o => o.Qty, f => f.Random.UInt(1, 3))
-                .RuleFor(o => o.Order, f => order)
-                .RuleFor(o => o.Product, f => f.PickRandom(products))
-                .Generate(numitems);
-            orderItems.AddRange(orderi);
+            order.Products = new Faker().PickRandom(products, numitems).ToList();
         }
-        context.AddRange(orderItems);
+
+        foreach (var product in products)
+        {
+            var numitems = new Faker().Random.Int(1, 4);
+            product.Orders = new Faker().PickRandom(orders, numitems).ToList();
+
+        }
+
+        context.SaveChanges();
     }
 }

--- a/SeedMaster/Interfaces/IActualSeeder.cs
+++ b/SeedMaster/Interfaces/IActualSeeder.cs
@@ -11,6 +11,11 @@ namespace Nudes.SeedMaster.Interfaces;
 /// </summary>
 /// <typeparam name="TContext">Context Type</typeparam>
 /// <typeparam name="TDbSet">DbSet Type</typeparam>
+/// 
+public interface IActualSeeder<TDbSet, TDbSet2, TContext> where TContext : DbContext
+{
+    public abstract void Seed(TContext context, ILogger logger);
+}
 public interface IActualSeeder<TDbSet, TContext> where TContext : DbContext
 {
     public abstract void Seed(TContext context, ILogger logger);

--- a/SeedMaster/ScanResult.cs
+++ b/SeedMaster/ScanResult.cs
@@ -12,7 +12,8 @@ public partial class SeedScanner
         public enum SeedTypes
         {
             GlobalSeed,
-            EntitySeed
+            EntitySeed,
+            ManyToManySeed
         };
 
         /// <summary>


### PR DESCRIPTION
Added a new Interface that receives two contexts, so created a new seed queue called ManyToMany seeds in SeedScanner class.
That way we can call after the seed of all others stuffs, and just seed te relation between those classes.

Removed OrderItem table and reconfigured POC Context and classes to test.